### PR TITLE
Non existing version of clean-css

### DIFF
--- a/app/templates/core/_package.json
+++ b/app/templates/core/_package.json
@@ -22,7 +22,7 @@
       "angular-mocks": "github:angular/bower-angular-mocks@~1.5.0",
       "babel": "npm:babel-core@^5.8.24",
       "babel-runtime": "npm:babel-runtime@^5.8.20",
-      "clean-css": "npm:clean-css@^3.14.3",
+      "clean-css": "npm:clean-css@^3.4.13",
       "core-js": "npm:core-js@^1.1.4"
     }
   },


### PR DESCRIPTION
In response to issue #15 
The version "3.14.3" is most likely a typo, introduced in commit c93ab4f98ed3468c1262fda135d3fc113d473fe1

Meanwhile, the team from clean-css is pushing out a lot of new versions, currently they are at 3.4.18
