### PR TITLE
Added gulp-angular-embed-templates to embed templates from templateURL

### DIFF
--- a/app/templates/core/_package.json
+++ b/app/templates/core/_package.json
@@ -38,6 +38,7 @@
     "generator-angular-lazy": "~0.6.5",
     "glob": "^7.0.3",
     "gulp": "^3.9.0",
+    "gulp-angular-embed-templates": "^2.3.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-babel": "^6.1.0",
     "gulp-connect": "^5.0.0",

--- a/app/templates/core/gulp-tasks/compile-source.js
+++ b/app/templates/core/gulp-tasks/compile-source.js
@@ -3,10 +3,12 @@
 const babel = require('gulp-babel');
 const plumber = require('gulp-plumber');
 const sourcemaps = require('gulp-sourcemaps');
+const embedTemplates = require('gulp-angular-embed-templates');
 
 module.exports = (gulp, config) => {
     gulp.task('compile-source', () => gulp
         .src(config.paths.sources)
+        .pipe(embedTemplates())
         .pipe(plumber())
         .pipe(sourcemaps.init())
         .pipe(babel({

--- a/app/templates/core/gulp-tasks/watch.js
+++ b/app/templates/core/gulp-tasks/watch.js
@@ -4,6 +4,7 @@ module.exports = (gulp, config, sync) => {
     gulp.task('watch', () => {
         gulp.watch(config.paths.stylesheets, sync.sync(['compile-stylesheets', 'notify-recompiled']));
         gulp.watch(config.paths.scripts, sync.sync(['compile-source', 'eslint', 'notify-recompiled']));
+        gulp.watch(config.paths.html, sync.sync(['compile-source', 'notify-recompiled']));
         gulp.watch(config.paths.html, sync.sync(['copy-static', 'htmlhint', 'notify-recompiled']));
         gulp.watch(config.paths.static, sync.sync(['copy-static', 'notify-recompiled']));
     });


### PR DESCRIPTION
Added gulp-angular-embed-templates so that one does not have to use absolute paths for templateURL for modal windows and template from templateURL is automatically embedded during build.